### PR TITLE
fix 修复server/index.js "config.dev" 逻辑错误

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ import { resolve } from 'path'
 
 // Import and Set Nuxt.js options
 let config = require('../nuxt.config.js')
-config.dev = !(process.env === 'production')
+config.dev = !(process.env.NODE_ENV === 'production') 
 
 const r = path => resolve(__dirname, path)
 const host = process.env.HOST || '127.0.0.1'


### PR DESCRIPTION
此处 process.env 是nodejs对象，并非字符串。